### PR TITLE
Descriptor level `supported_platforms` json schema update

### DIFF
--- a/docs/json-schemas/descriptor.html
+++ b/docs/json-schemas/descriptor.html
@@ -1145,6 +1145,994 @@
         </div>
     </div>
 </div>
+<div class="accordion" id="accordionsupported_platforms">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms"
+                        aria-expanded="" aria-controls="supported_platforms" onclick="setAnchor('#supported_platforms')"><span class="property-name">supported_platforms</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms"
+             data-parent="#accordionsupported_platforms">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a></div><span class="badge badge-dark value-type">Type: object</span> <span class="badge badge-success default-value">Default: {"platform": ["linux/amd64"]}</span><br/>
+<span class="description"><p>Specifies the supported target platforms (OS, CPU architecture, CPU variant) for the install of this descriptor, and optionally overrides install instructions for a specific platform. Uses the same <a href="https://docs.docker.com/desktop/multi-arch/">architecture naming conventions as Docker</a>.</p>
+</span>
+            
+
+            
+            
+
+            <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="supported_platforms_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div><div id="supported_platforms_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div><button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#supported_platforms_ex3" aria-controls="supported_platforms_ex3"></button><div id="supported_platforms_ex3" class="collapse jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">],</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;install_override&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="p">{</span><span class="w"></span>
+<span class="w">            </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="s2">&quot;linux/arm64&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">            </span><span class="s2">&quot;install&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">{</span><span class="w"></span>
+<span class="w">                </span><span class="s2">&quot;dockerfile&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">                    </span><span class="s2">&quot;ARG PWSH_VERSION=&#39;latest&#39;&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">                    </span><span class="s2">&quot;ARG PWSH_DIRECTORY=&#39;/opt/microsoft/powershell&#39;&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">                    </span><span class="s2">&quot;RUN mkdir -p ${PWSH_DIRECTORY} \\\n    &amp;&amp; curl --retry 5 --retry-delay 5 -s https://api.github.com/repos/powershell/powershell/releases/${PWSH_VERSION} \\\n        | grep browser_download_url \\\n        | grep linux-arm64 \\\n        | cut -d &#39;\&quot;&#39; -f 4 \\\n        | xargs -n 1 wget -O - \\\n        | tar -xzC ${PWSH_DIRECTORY} \\\n    &amp;&amp; ln -sf ${PWSH_DIRECTORY}/pwsh /usr/bin/pwsh\n&quot;</span><span class="w"></span>
+<span class="w">                </span><span class="p">]</span><span class="w"></span>
+<span class="w">            </span><span class="p">}</span><span class="w"></span>
+<span class="w">        </span><span class="p">}</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_platform">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_platform">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_platform"
+                        aria-expanded="" aria-controls="supported_platforms_platform" onclick="setAnchor('#supported_platforms_platform')"><span class="property-name">platform</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_platform"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_platform"
+             data-parent="#accordionsupported_platforms_platform">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_platform" onclick="anchorLink('supported_platforms_platform')">platform</a></div><span class="badge badge-dark value-type">Type: array of enum (of string)</span> <span class="badge badge-success default-value">Default: ["linux/amd64"]</span><br/>
+<span class="description"><p>The list of target platforms (OS/CPU architecture/CPU Variant) that this descriptor supports.</p>
+</span>
+            
+
+            
+            
+
+            <p><span class="badge badge-light restriction unique-items-restriction" id="supported_platforms_platform_uniqueItems">All items must be unique</span></p><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_platform_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_platform" onclick="anchorLink('supported_platforms_platform')">platform</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_platform_items" onclick="anchorLink('supported_platforms_platform_items')">Target platform</a></div><span class="badge badge-dark value-type">Type: enum (of string)</span> <span class="badge badge-success default-value">Default: "linux/amd64"</span><br/>
+<span class="description"><p>Target platforms <a href="https://github.com/docker-library/bashbrew/blob/v0.1.2/architecture/oci-platform.go#L14-L27">available to use on Docker</a>.<br />
+<strong><em>Please note that Megalinter does not support all Docker's platforms.</em></strong></p>
+</span><div class="enum-value" id="supported_platforms_platform_items_enum">
+                <h4>Must be one of:</h4>
+                <ul class="list-group"><li class="list-group-item enum-item">"linux/amd64"</li><li class="list-group-item enum-item">"linux/arm64"</li><li class="list-group-item enum-item">"linux/arm/v7"</li><li class="list-group-item enum-item">"linux/arm/v5"</li><li class="list-group-item enum-item">"linux/386"</li><li class="list-group-item enum-item">"linux/mips64le"</li><li class="list-group-item enum-item">"linux/ppc64le"</li><li class="list-group-item enum-item">"linux/riscv64"</li><li class="list-group-item enum-item">"linux/s390x"</li><li class="list-group-item enum-item">"windows/amd64"</li></ul>
+                </div>
+            
+
+            
+            
+
+            
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="supported_platforms_platform_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div><div id="supported_platforms_platform_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override"
+                        aria-expanded="" aria-controls="supported_platforms_install_override" onclick="setAnchor('#supported_platforms_install_override')"><span class="property-name">install_override</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override"
+             data-parent="#accordionsupported_platforms_install_override">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a></div><span class="badge badge-dark value-type">Type: array of object</span><br/>
+<span class="description"><p>Defines special installation steps for a specific platform (OS/CPU architecture/CPU variant), replacing the descriptor's install instructions given in the <code>install</code> node for this target platform only.</p>
+</span>
+            
+
+            
+            
+
+            <h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_install_override_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+            
+
+            
+            
+
+            
+<div class="accordion" id="accordionsupported_platforms_install_override_items_platform">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_platform">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_platform"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_platform" onclick="setAnchor('#supported_platforms_install_override_items_platform')"><span class="property-name">platform</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_platform"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_platform"
+             data-parent="#accordionsupported_platforms_install_override_items_platform">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_platform" onclick="anchorLink('supported_platforms_install_override_items_platform')">platform</a></div><span class="badge badge-dark value-type">Type: string</span> <span class="badge badge-success default-value">Default: "linux/arm64"</span><br/>
+<span class="description"><p>Target platform (OS/CPU architecture/CPU variant) to define special installation steps for.</p>
+</span>
+
+    <div class="enum-value" id="supported_platforms_install_override_items_platform_enum">
+                <h4>Must be one of:</h4>
+                <ul class="list-group"><li class="list-group-item enum-item">"linux/amd64"</li><li class="list-group-item enum-item">"linux/arm64"</li><li class="list-group-item enum-item">"linux/arm/v7"</li><li class="list-group-item enum-item">"linux/arm/v5"</li><li class="list-group-item enum-item">"linux/386"</li><li class="list-group-item enum-item">"linux/mips64le"</li><li class="list-group-item enum-item">"linux/ppc64le"</li><li class="list-group-item enum-item">"linux/riscv64"</li><li class="list-group-item enum-item">"linux/s390x"</li><li class="list-group-item enum-item">"windows/amd64"</li></ul>
+                </div>
+            
+
+            
+            
+
+            
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override_items_install">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_install">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_install"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_install" onclick="setAnchor('#supported_platforms_install_override_items_install')"><span class="property-name">install</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_install"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_install"
+             data-parent="#accordionsupported_platforms_install_override_items_install">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a></div><span class="badge badge-dark value-type">Type: object</span> <span class="badge badge-success default-value">Default: {}</span><br/>
+<span class="description"><p>List of apk, dockerfile instructions, npm/pip/gem packages required to use the descriptor's linters.<br />
+These special installation steps replace the instructions in the descriptor's <a href="#install"><code>install</code></a> node when using this target platform pair only.</p>
+</span>
+
+    
+            
+
+            
+            
+
+            <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="supported_platforms_install_override_items_install_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;apk&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;openjdk11&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div><div id="supported_platforms_install_override_items_install_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;dockerfile&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;ENV PATH=\&quot;$JAVA_HOME/bin:${PATH}\&quot;&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div><div id="supported_platforms_install_override_items_install_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;npm&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
+<span class="w">        </span><span class="s2">&quot;sfdx-cli&quot;</span><span class="w"></span>
+<span class="w">    </span><span class="p">]</span><span class="w"></span>
+<span class="p">}</span><span class="w"></span>
+</pre></div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override_items_install_apk">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_install_apk">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_install_apk"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_install_apk" onclick="setAnchor('#supported_platforms_install_override_items_install_apk')"><span class="property-name">apk</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_install_apk"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_install_apk"
+             data-parent="#accordionsupported_platforms_install_override_items_install_apk">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_apk" onclick="anchorLink('supported_platforms_install_override_items_install_apk')">apk</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>APK packages identifiers (with or without version)</p>
+</span>
+            
+
+            
+            
+
+            <h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_install_override_items_install_apk_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_apk" onclick="anchorLink('supported_platforms_install_override_items_install_apk')">apk</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_apk_items" onclick="anchorLink('supported_platforms_install_override_items_install_apk_items')">apk items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+            
+
+            
+            
+
+            
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><div id="supported_platforms_install_override_items_install_apk_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;openjdk11&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override_items_install_dockerfile">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_install_dockerfile">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_install_dockerfile"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_install_dockerfile" onclick="setAnchor('#supported_platforms_install_override_items_install_dockerfile')"><span class="property-name">dockerfile</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_install_dockerfile"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_install_dockerfile"
+             data-parent="#accordionsupported_platforms_install_override_items_install_dockerfile">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_dockerfile" onclick="anchorLink('supported_platforms_install_override_items_install_dockerfile')">dockerfile</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>Will be automatically integrated in generated Dockerfile</p>
+</span>
+            
+
+            
+            
+
+            <h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_install_override_items_install_dockerfile_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_dockerfile" onclick="anchorLink('supported_platforms_install_override_items_install_dockerfile')">dockerfile</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_dockerfile_items" onclick="anchorLink('supported_platforms_install_override_items_install_dockerfile_items')">dockerfile items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+            
+
+            
+            
+
+            
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><div id="supported_platforms_install_override_items_install_dockerfile_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;ENV PATH=\&quot;$JAVA_HOME/bin:${PATH}\&quot;&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override_items_install_gem">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_install_gem">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_install_gem"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_install_gem" onclick="setAnchor('#supported_platforms_install_override_items_install_gem')"><span class="property-name">gem</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_install_gem"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_install_gem"
+             data-parent="#accordionsupported_platforms_install_override_items_install_gem">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_gem" onclick="anchorLink('supported_platforms_install_override_items_install_gem')">gem</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>GEM packages identifiers (with or without version)</p>
+</span>
+            
+
+            
+            
+
+            <h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_install_override_items_install_gem_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_gem" onclick="anchorLink('supported_platforms_install_override_items_install_gem')">gem</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_gem_items" onclick="anchorLink('supported_platforms_install_override_items_install_gem_items')">gem items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+            
+
+            
+            
+
+            
+        </div>
+    </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override_items_install_npm">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_install_npm">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_install_npm"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_install_npm" onclick="setAnchor('#supported_platforms_install_override_items_install_npm')"><span class="property-name">npm</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_install_npm"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_install_npm"
+             data-parent="#accordionsupported_platforms_install_override_items_install_npm">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_npm" onclick="anchorLink('supported_platforms_install_override_items_install_npm')">npm</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>NPM packages identifiers (with or without version)</p>
+</span>
+            
+
+            
+            
+
+            <h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_install_override_items_install_npm_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_npm" onclick="anchorLink('supported_platforms_install_override_items_install_npm')">npm</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_npm_items" onclick="anchorLink('supported_platforms_install_override_items_install_npm_items')">npm items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+            
+
+            
+            
+
+            
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><div id="supported_platforms_install_override_items_install_npm_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;sfdx-cli&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsupported_platforms_install_override_items_install_pip">
+    <div class="card">
+        <div class="card-header" id="headingsupported_platforms_install_override_items_install_pip">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#supported_platforms_install_override_items_install_pip"
+                        aria-expanded="" aria-controls="supported_platforms_install_override_items_install_pip" onclick="setAnchor('#supported_platforms_install_override_items_install_pip')"><span class="property-name">pip</span></button>
+            </h2>
+        </div>
+
+        <div id="supported_platforms_install_override_items_install_pip"
+             class="collapse property-definition-div" aria-labelledby="headingsupported_platforms_install_override_items_install_pip"
+             data-parent="#accordionsupported_platforms_install_override_items_install_pip">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_pip" onclick="anchorLink('supported_platforms_install_override_items_install_pip')">pip</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>PIP packages identifiers (with or without version)</p>
+</span>
+            
+
+            
+            
+
+            <h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="supported_platforms_install_override_items_install_pip_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms" onclick="anchorLink('supported_platforms')">supported_platforms</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override" onclick="anchorLink('supported_platforms_install_override')">install_override</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items" onclick="anchorLink('supported_platforms_install_override_items')">install_override items</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install" onclick="anchorLink('supported_platforms_install_override_items_install')">install</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_pip" onclick="anchorLink('supported_platforms_install_override_items_install_pip')">pip</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#supported_platforms_install_override_items_install_pip_items" onclick="anchorLink('supported_platforms_install_override_items_install_pip_items')">pip items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+            
+
+            
+            
+
+            
+        </div>
+    </div>
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+        </div>
+    </div>
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
 <div class="accordion" id="accordionlint_all_files">
     <div class="card">
         <div class="card-header" id="headinglint_all_files">
@@ -7369,6 +8357,6 @@ These special installation steps replace the instructions in the <a href="#linte
 </div>
 
     <footer>
-        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2022-07-04 at 02:19:34 +0000</p>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2022-07-10 at 20:36:08 +0000</p>
     </footer></body>
 </html>

--- a/docs/json-schemas/descriptor.html
+++ b/docs/json-schemas/descriptor.html
@@ -1287,18 +1287,14 @@
         </div>
     </div><br/>
 <div class="badge badge-secondary">Examples:</div>
-<br/><div id="supported_platforms_platform_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
-<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
-<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
-<span class="w">        </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
-<span class="w">    </span><span class="p">]</span><span class="w"></span>
-<span class="p">}</span><span class="w"></span>
+<br/><div id="supported_platforms_platform_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
 </pre></div>
-</div><div id="supported_platforms_platform_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
-<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
-<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="w"></span>
-<span class="w">    </span><span class="p">]</span><span class="w"></span>
-<span class="p">}</span><span class="w"></span>
+</div><div id="supported_platforms_platform_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;linux/amd64&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
 </pre></div>
 </div>
             </div>
@@ -5498,18 +5494,14 @@ These special installation steps replace the instructions in the descriptor's <a
         </div>
     </div><br/>
 <div class="badge badge-secondary">Examples:</div>
-<br/><div id="linters_items_supported_platforms_platform_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
-<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
-<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
-<span class="w">        </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
-<span class="w">    </span><span class="p">]</span><span class="w"></span>
-<span class="p">}</span><span class="w"></span>
+<br/><div id="linters_items_supported_platforms_platform_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;linux/amd64&quot;</span><span class="p">,</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;linux/arm64&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
 </pre></div>
-</div><div id="linters_items_supported_platforms_platform_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">{</span><span class="w"></span>
-<span class="w">    </span><span class="s2">&quot;platform&quot;</span><span class="o">:</span><span class="w"> </span><span class="p">[</span><span class="w"></span>
-<span class="w">        </span><span class="s2">&quot;linux/amd64&quot;</span><span class="w"></span>
-<span class="w">    </span><span class="p">]</span><span class="w"></span>
-<span class="p">}</span><span class="w"></span>
+</div><div id="linters_items_supported_platforms_platform_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span><span class="w"></span>
+<span class="w">    </span><span class="s2">&quot;linux/amd64&quot;</span><span class="w"></span>
+<span class="p">]</span><span class="w"></span>
 </pre></div>
 </div>
             </div>
@@ -8357,6 +8349,6 @@ These special installation steps replace the instructions in the <a href="#linte
 </div>
 
     <footer>
-        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2022-07-10 at 20:36:08 +0000</p>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2022-07-10 at 21:04:34 +0000</p>
     </footer></body>
 </html>

--- a/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
@@ -352,17 +352,13 @@
             "default": "linux/amd64"
           },
           "examples": [
-            {
-              "platform": [
-                "linux/amd64",
-                "linux/arm64"
-              ]
-            },
-            {
-              "platform": [
-                "linux/amd64"
-              ]
-            }
+            [
+              "linux/amd64",
+              "linux/arm64"
+            ],
+            [
+              "linux/amd64"
+            ]
           ],
           "type": "array",
           "title": "List of target platforms"
@@ -1040,17 +1036,13 @@
                   "default": "linux/amd64"
                 },
                 "examples": [
-                  {
-                    "platform": [
-                      "linux/amd64",
-                      "linux/arm64"
-                    ]
-                  },
-                  {
-                    "platform": [
-                      "linux/amd64"
-                    ]
-                  }
+                  [
+                    "linux/amd64",
+                    "linux/arm64"
+                  ],
+                  [
+                    "linux/amd64"
+                  ]
                 ],
                 "type": "array",
                 "title": "List of target platforms"

--- a/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
+++ b/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json
@@ -322,6 +322,119 @@
       "title": "Installation requirements",
       "type": "object"
     },
+    "supported_platforms": {
+      "$id": "#/properties/supported_platforms",
+      "description": "Specifies the supported target platforms (OS, CPU architecture, CPU variant) for the install of this descriptor, and optionally overrides install instructions for a specific platform. Uses the same [architecture naming conventions as Docker](https://docs.docker.com/desktop/multi-arch/).",
+      "properties": {
+        "platform": {
+          "$id": "#/properties/supported_platforms/properties/platform",
+          "description": "The list of target platforms (OS/CPU architecture/CPU Variant) that this descriptor supports.",
+          "default": [
+            "linux/amd64"
+          ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "description": "Target platforms [available to use on Docker](https://github.com/docker-library/bashbrew/blob/v0.1.2/architecture/oci-platform.go#L14-L27).\n***Please note that Megalinter does not support all Docker's platforms.***",
+            "enum": [
+              "linux/amd64",
+              "linux/arm64",
+              "linux/arm/v7",
+              "linux/arm/v5",
+              "linux/386",
+              "linux/mips64le",
+              "linux/ppc64le",
+              "linux/riscv64",
+              "linux/s390x",
+              "windows/amd64"
+            ],
+            "title": "Target platform",
+            "default": "linux/amd64"
+          },
+          "examples": [
+            {
+              "platform": [
+                "linux/amd64",
+                "linux/arm64"
+              ]
+            },
+            {
+              "platform": [
+                "linux/amd64"
+              ]
+            }
+          ],
+          "type": "array",
+          "title": "List of target platforms"
+        },
+        "install_override": {
+          "$id": "#/properties/supported_platforms/properties/install_override",
+          "description": "Defines special installation steps for a specific platform (OS/CPU architecture/CPU variant), replacing the descriptor's install instructions given in the `install` node for this target platform only.",
+          "items": {
+            "properties": {
+              "platform": {
+                "$id": "#/properties/supported_platforms/properties/install_override/items/properties/platform",
+                "description": "Target platform (OS/CPU architecture/CPU variant) to define special installation steps for.",
+                "$ref": "#/properties/supported_platforms/properties/platform/items",
+                "default": "linux/arm64",
+                "type": "string",
+                "examples": []
+              },
+              "install": {
+                "$id": "#/properties/supported_platforms/properties/install_override/items/properties/install",
+                "description": "List of apk, dockerfile instructions, npm/pip/gem packages required to use the descriptor's linters.\nThese special installation steps replace the instructions in the descriptor's [`install`](#install) node when using this target platform pair only.",
+                "$ref": "#/properties/install"
+              }
+            },
+            "type": "object",
+            "required": [
+              "platform",
+              "install"
+            ]
+          },
+          "title": "Installation requirements override",
+          "type": "array"
+        }
+      },
+      "default": {
+        "platform": [
+          "linux/amd64"
+        ]
+      },
+      "examples": [
+        {
+          "platform": [
+            "linux/amd64",
+            "linux/arm64"
+          ]
+        },
+        {
+          "platform": [
+            "linux/amd64"
+          ]
+        },
+        {
+          "platform": [
+            "linux/amd64",
+            "linux/arm64"
+          ],
+          "install_override": [
+            {
+              "platform": "linux/arm64",
+              "install": {
+                "dockerfile": [
+                  "ARG PWSH_VERSION='latest'",
+                  "ARG PWSH_DIRECTORY='/opt/microsoft/powershell'",
+                  "RUN mkdir -p ${PWSH_DIRECTORY} \\\n    && curl --retry 5 --retry-delay 5 -s https://api.github.com/repos/powershell/powershell/releases/${PWSH_VERSION} \\\n        | grep browser_download_url \\\n        | grep linux-arm64 \\\n        | cut -d '\"' -f 4 \\\n        | xargs -n 1 wget -O - \\\n        | tar -xzC ${PWSH_DIRECTORY} \\\n    && ln -sf ${PWSH_DIRECTORY}/pwsh /usr/bin/pwsh\n"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "title": "Supported platforms",
+      "type": "object"
+    },
     "lint_all_files": {
       "$id": "#/properties/lint_all_files",
       "default": false,


### PR DESCRIPTION

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Adds `supported_platforms`, and `supported_platforms` > `install_override` at the descriptor level, so usages of `install` like for the PowerShell descriptor can be adjusted too.

Relates to oxsecurity/megalinter#1553

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
